### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/dist/pdfjs.js
+++ b/dist/pdfjs.js
@@ -185,7 +185,7 @@ Document.prototype.render = function() {
 
 var TTFFont = require('ttfjs')
 var utils   = require('../../pdf/utils')
-var uuid    = require('node-uuid')
+var uuid    = require('uuid')
 
 var Font = module.exports = function(src) {
   this.uuid = uuid.v4()

--- a/lib/element/font/ttf.js
+++ b/lib/element/font/ttf.js
@@ -2,7 +2,7 @@
 
 var TTFFont = require('ttfjs')
 var utils   = require('../../pdf/utils')
-var uuid    = require('node-uuid')
+var uuid    = require('uuid')
 
 var Font = module.exports = function(src) {
   this.uuid = uuid.v4()

--- a/lib/image.js
+++ b/lib/image.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var utils = require('./pdf/utils')
-var uuid  = require('node-uuid')
+var uuid  = require('uuid')
 
 module.exports = function(src) {
   this.uuid = uuid.v4()

--- a/lib/pdf/index.js
+++ b/lib/pdf/index.js
@@ -4,7 +4,7 @@ var PDFObject  = require('./object/object')
 var PDFXObject = require('./object/xobject')
 var Pages      = require('./object/pages')
 var Page       = require('./object/page')
-var uuid       = require('node-uuid')
+var uuid       = require('uuid')
 var debug      = require('debug')('pdfjs')
 
 var version = require('../../package.json').version

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "base-64": "^0.1.0",
     "debug": "^2.2",
     "linebreak": "^0.3.0",
-    "node-uuid": "^1.4",
     "ttfjs": "^0.4.0",
-    "unorm": "^1.3"
+    "unorm": "^1.3",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "browserify": "^11.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.