### PR TITLE
Support for specifying document properties

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,17 @@ Creates a new [PDF document](document.md).
 - **fontSize** (default: 11) - the font size
 - **color** (default: black) - the font color as hex number (e.g. 0x000000)
 - **lineHeight** (default: 1.15) - the line height
+- **properties** - document properties - see below
+
+**Properties:**
+
+- **title** (string) - the document's title
+- **author** (string) - the name of the person who created the document
+- **subject** (string) - the subject of the document
+- **keywords** (string) - keywords associated with the document
+- **creator** (string) - if the document was converted to PDF from another format, the name of the conforming product that created the original document from which it was converted
+- **producer** (string, default: pdfjs v1.3 (github.com/rkusa/pdfjs)) -  if the document was converted to PDF from another format, the name of the conforming product that converted it to PDF
+- **creationDate** (date, default: `new Date()`) - the date and time the document was created
 
 **Example:**
 

--- a/lib/document.js
+++ b/lib/document.js
@@ -27,11 +27,10 @@ class Document extends Readable {
     })
 
     this.version = '1.3'
-    this.info = {
-      id: uuid.v4(),
+    this.info = Object.assign({
       producer: `pdfjs v${version} (github.com/rkusa/pdfjs)`,
       creationDate: new Date(),
-    }
+    }, opts.properties, { id: uuid.v4() })
     this.width = opts.width || 595.296
     this.height = opts.height || 841.896
 


### PR DESCRIPTION
See the [update docs](https://github.com/rhodgkins/pdfjs/tree/doc-properties/docs#new-pdfdocumentopts-properties).

All properties taken from [the PDF spec](http://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/PDF32000_2008.pdf) (page 550 - table 317: _Entries in the document information dictionary_).