### PR TITLE
Make tests running on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bugs": "https://github.com/rkusa/pdfjs/issues",
   "main": "lib/",
   "scripts": {
-    "test": "node test/index.js test/pdfs/**/*.js"
+    "test": "node test/index.js"
   },
   "dependencies": {
     "@rkusa/linebreak": "^1.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ process.env.TZ = 'Europe/Berlin'
 
 const args = process.argv.slice(2)
 if (args.length) {
-  run(args, true)
+  run(args.map((a) => path.join(__dirname, a)), true)
 } else {
   glob(path.join(__dirname, 'pdfs/**/*.js'), function (err, files) {
     if (err) throw err
@@ -44,7 +44,7 @@ function run(files, force) {
     const expectationPath = path.join(dirname, basename + '.pdf')
     const resultPath      = path.join(dirname, basename + '.result.pdf')
 
-    const script = require(path.join('../', scriptPath))
+    const script = require(scriptPath)
 
     let doc = new pdf.Document({
       font:       f.font.afm.regular,


### PR DESCRIPTION
The issue is that the glob `node test/index.js test/pdfs/**/*.js` in the command is not automatically expanded on windows. I changed the behavior for the default `npm test` to rely on js glob implementation.

Developer can still test all using
```
npm test
```

or single test using
```
npm test pdfs/text/append.js
```