### PR TITLE
Use correct parsing of escaped characters in strings

### DIFF
--- a/lib/object/string.js
+++ b/lib/object/string.js
@@ -55,12 +55,12 @@ class PDFString {
     let open = 0
     let c
     while (!done && (c = lexer._nextCharCode()) >= 0) {
-      switch (true) {
-        case c === 0x28: // (
+      switch (c) {
+        case 0x28: // (
           open++
           str += String.fromCharCode('(')
           break
-        case c === 0x29: // )
+        case 0x29: // )
           if (open === 0) {
             done = true
           } else {
@@ -68,7 +68,7 @@ class PDFString {
             str += String.fromCharCode(')')
           }
           break
-        case c === 0x5c: // \
+        case 0x5c: // \
           c = lexer._nextCharCode()
           switch (c) {
             case 0x6e: // \n

--- a/lib/object/string.js
+++ b/lib/object/string.js
@@ -91,9 +91,21 @@ class PDFString {
             case 0x5c: // '\'
               str += String.fromCharCode(c)
               break
+            case 0x30: // 0
+            case 0x31: // 1
+            case 0x32: // 2
+            case 0x33: // 3
+            case 0x34: // 4
+            case 0x35: // 5
+            case 0x36: // 6
+            case 0x37: // 7
+            case 0x38: // 8
+            case 0x39: // 9
+              const oct = String.fromCharCode(c) + lexer.readString(2)
+              str += String.fromCharCode(parseInt(oct, 8))
+              break
             default:
-              const hex = lexer.readString(3)
-              str += String.fromCharCode(parseInt(hex, 16))
+              lexer.shift(-1)
               break
           }
           break


### PR DESCRIPTION
According to [this PDF spec document](https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDF32000_2008.pdf) (page 15), digits after a backslash are supposed to be parsed as octal and not hex.
Also, if the character immediately following the backslash is not one of the ones in the list (e.g. if it's 13 10 (CR LF)), the backslash should just be skipped and parsing resumed.
So I added cases for all digits and changed the default case to roll back the lexer's position one character.

There was a bug where the hex parsing skipped the character that was just read (the first digit in the escape sequence, right after `case c === 0x5c:`) which introduced an infinite loop in the following PDF:
[LGH 311.pdf](https://github.com/rkusa/pdfjs/files/2383754/LGH.311.pdf)
This is why I added the `lexer.shift(-1)` in the default case.

Basically an escaped character caused the lexer to keep going past the end of the string and just kept trying to parse way past the end of the entire buffer until it crashed by consuming too much memory.

I also noticed in another pdf (which I can't share since it's a personal invoice) which had CR/LF immediately after the backslash but the CR/LF wasn't skipped because the cases for `0x0d` and `0x0a` weren't getting matched.
The problem was the inconsistent use of a `switch (true)` and those two cases were just `case 0x0d:` instead of `case c === 0x0d:`.
Instead of switching those two cases I swapped to a `switch (c)` in order for this not to be an issue in the future :)

I didn't add a test case for it since I didn't really know where to put it. Seeing as this infinite loop caused our production site to hang until it ran OOM and restarted, I felt I just had to try to identify and fix the issue ASAP instead of posting an issue :D

This would also fix parsing of non-ascii characters like the swedish "ö" for example, which is escaped in a PDF as "\366".