### PR TITLE
Fix PDF 1.2 name  # escape logic

### DIFF
--- a/lib/object/name.js
+++ b/lib/object/name.js
@@ -37,7 +37,7 @@ class PDFName {
       if (code > 0xff) {
         code = 0x5f
       }
-      return '#' + code
+      return '#' + Number(code).toString(16);
     })
 
     this.name = name

--- a/lib/object/name.js
+++ b/lib/object/name.js
@@ -32,7 +32,7 @@ class PDFName {
       if (code > 0xff) {
         code = 0x5f
       }
-      return '#' + Number(code).toString(16);
+      return '#' + Number(code).toString(16)
     })
 
     // Add # in front of delimiter characters
@@ -48,7 +48,7 @@ class PDFName {
     //     7d  }
     name = name.replace(/[\x25\x28\x29\x2f\x3c\x3e\x5b\x5d\x7b\x7d]/g, function(c) {
       let code = c.charCodeAt(0)
-      return '#' + Number(code).toString(16);
+      return '#' + Number(code).toString(16)
     })
 
     this.name = name

--- a/lib/object/name.js
+++ b/lib/object/name.js
@@ -19,11 +19,6 @@ class PDFName {
       throw new Error('A Name mustn\'t contain the null characters')
     }
 
-    // delimiter characters are not allowed
-    if (name.match(/[\(\)<>\[\]\{\}\/\%]/)) {
-      throw new Error('A Name mustn\'t contain delimiter characters')
-    }
-
     name = name.toString()
 
     // Beginning with PDF 1.2, any character except null (character code 0)
@@ -37,6 +32,22 @@ class PDFName {
       if (code > 0xff) {
         code = 0x5f
       }
+      return '#' + Number(code).toString(16);
+    })
+
+    // Add # in front of delimiter characters
+    //     25  %
+    //     28  (
+    //     29  )
+    //     2f  /
+    //     3c  <
+    //     3e  >
+    //     5b  [
+    //     5d  ]
+    //     7b  {
+    //     7d  }
+    name = name.replace(/[\x25\x28\x29\x2f\x3c\x3e\x5b\x5d\x7b\x7d]/g, function(c) {
+      let code = c.charCodeAt(0)
       return '#' + Number(code).toString(16);
     })
 


### PR DESCRIPTION
Fixed the following issues:
- Hex codes should be used instead of DEC
- Delimiter characters escaped by # in name should work (for example parsing the following fails `/Name/Adobe#20Acrobat#20Reader#20DC#20#2832-bit#29/OS` as it first got converted to 'Adobe Acrobat Reader DC (32-bit)' after which it failed due to the delimiter check ("A Name mustn't contain delimiter characters")