### PR TITLE
Fix require pako inflate

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -49,7 +49,7 @@ exports.inflate = function(obj) {
     predictor = params.get("Predictor")
   }
 
-  const inflate = require('pako/lib/inflate.js').inflate
+  const inflate = require('pako').inflate
   let res = inflate(obj.content.content)
 
   if (predictor === 1) {


### PR DESCRIPTION
fix the error below

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/inflate.js' is not defined by "exports" in /app/node_modules/pdfjs/node_modules/pako/package.json

at throwExportsNotFound (internal/modules/esm/resolve.js:285:9)
at packageExportsResolve (internal/modules/esm/resolve.js:491:3)
at resolveExports (internal/modules/cjs/loader.js:450:36)
at Function.Module._findPath (internal/modules/cjs/loader.js:490:31)
at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:27)
at Function.Module._resolveFilename (/app/node_modules/tsconfig-paths/lib/register.js:75:40)
at Module.Hook._require.Module.require (/usr/lib/node_modules/pm2/node_modules/require-in-the-middle/index.js:61:29)
at require (internal/modules/cjs/helpers.js:88:18)
at Object.exports.inflate (/app/node_modules/pdfjs/lib/util.js:52:19)
at Function.parseXrefObject (/app/node_modules/pdfjs/lib/object/xref.js:118:25)
```
