### PR TITLE
throw a new error in order to have a correct stack trace

### DIFF
--- a/lib/errors/already-ended.js
+++ b/lib/errors/already-ended.js
@@ -1,0 +1,1 @@
+module.exports = class AlreadyEndedError extends Error {}

--- a/lib/fragment.js
+++ b/lib/fragment.js
@@ -6,8 +6,7 @@ const util = require('./util')
 const renderImage = require('./image/render')
 const PDFImage = require('./image/pdf')
 const JPEGImage = require('./image/jpeg')
-
-const ALREADY_ENDED_ERROR = new Error('already ended')
+const AlreadyEndedError = require('./errors/already-ended')
 
 module.exports = class Fragment {
   constructor(doc, parent) {
@@ -38,7 +37,7 @@ module.exports = class Fragment {
 
   _begin(ctx) {
     if (this._ended) {
-      throw ALREADY_ENDED_ERROR
+      throw new AlreadyEndedError()
     }
 
     if (this._current) {
@@ -66,7 +65,7 @@ module.exports = class Fragment {
 
   end() {
     if (this._ended) {
-      throw ALREADY_ENDED_ERROR
+      throw new AlreadyEndedError()
     }
 
     if (this._current) {


### PR DESCRIPTION
The stack trace of the error was always at line `const ALREADY_ENDED_ERROR = new Error('already ended')`. It was sometimes difficult to debug this error.
Before : 
![image](https://user-images.githubusercontent.com/9933000/213144424-97e93fe7-338b-417d-9206-80d7a351c5a1.png)

After : 
![image](https://user-images.githubusercontent.com/9933000/213144632-8e77c429-3297-4b75-adfe-a26d1e87f58c.png)

