### PR TITLE
Fix Document.asBuffer types

### DIFF
--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -91,7 +91,20 @@ declare module "pdfjs" {
          * Can be used to render the document as a buffer
          * @param callback callback called with either error or buffer
          */
-        asBuffer(callback?: (err: Error, data: Buffer) => void): void;
+        asBuffer(callback: (err: Error, data: Buffer) => void): Promise<unknown>;
+
+        /**
+         * Can be used to render the document as a buffer
+         * @param opts can be used to control if the document will automatically be ended
+         */
+        asBuffer(opts: AsBufferOptions): Promise<Buffer>;
+
+        /**
+         * Can be used to render the document as a buffer
+         * @param opts can be used to control if the document will automatically be ended
+         * @param callback callback called with either error or buffer
+         */
+        asBuffer(opts: AsBufferOptions, callback: (err: Error, data: Buffer) => void): Promise<unknown>;
 
         /**
          * Add a header to the document
@@ -131,6 +144,8 @@ declare module "pdfjs" {
          */
         outline(title: string, destination: string, parent?: string | number): void;
     }
+
+    type AsBufferOptions = { end: boolean };
 
     export class Fragment {
         end(): void; // TODO


### PR DESCRIPTION
The types for `Document.asBuffer` are currently not correct and do not include the `opts` argument. I changed this and the return type for each possible argument combination.