### PR TITLE
Add types for document size properties

### DIFF
--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -69,6 +69,16 @@ declare module "pdfjs" {
         info: DocumentProperties & { id: string };
 
         /**
+         * The documents width.
+         */
+        width: number;
+
+        /**
+         * The documents height.
+         */
+        height: number;
+
+        /**
          * Document is a Readable stream and can therefore piped into other streams
          * @param dest destination
          * @param opts options


### PR DESCRIPTION
A `Document` instance has `width` and `height` properties but those are unfortunately missing from the TypeScript definitions. This PR changes that.